### PR TITLE
Default BigQuery to 'batch' mode priority

### DIFF
--- a/CHANGELOG_jmesterh_star_5883_batch_mode.adoc
+++ b/CHANGELOG_jmesterh_star_5883_batch_mode.adoc
@@ -1,0 +1,1 @@
+* ({uri-jira}/STAR-5883[STAR-5883]) - BigQuery tool now defaults to Priority.BATCH, to avoid > 100 interactive job quota cancellations

--- a/src/main/wdl/bigquery.wdl
+++ b/src/main/wdl/bigquery.wdl
@@ -44,7 +44,7 @@ task Query {
       drop: { description: "Drop any existing destination table before executing query (default)" }
       createDisposition: { description: "One of [ (CREATE_IF_NEEDED), CREATE_NEVER ]" }
       writeDisposition: { description: "One of [ WRITE_APPEND, WRITE_TRUNCATE, (WRITE_EMPTY) ]" }
-      queryPriority: { description: "Query priority [ INTERACTIVE, BATCH ]" }
+      queryPriority: { description: "Query priority [ INTERACTIVE, (BATCH) ]" }
       useQueryCache: { description: "Use BigQuery query cache if possible (default: no)" }
     }
 
@@ -65,7 +65,7 @@ task Query {
       EncryptionConfiguration? destinationEncryptionConfiguration
       String createDisposition = "CREATE_IF_NEEDED"
       String writeDisposition = "WRITE_EMPTY"
-      String queryPriority = "INTERACTIVE"
+      String queryPriority = "BATCH"
       Boolean useQueryCache = true
 
       Int cpu = 1


### PR DESCRIPTION
Change BigQuery query priority to default to Priority.BATCH mode instead of Priority.INTERACTIVE. This prevents pipelines from being killed when exceeding > 100 parallel interactive queries. 
